### PR TITLE
Fix NPE cause by calling collectOne() when using JsonSurferJackson instance

### DIFF
--- a/jsurfer-all/src/test/java/org/jsfr/json/JsonSurferTest.java
+++ b/jsurfer-all/src/test/java/org/jsfr/json/JsonSurferTest.java
@@ -738,5 +738,10 @@ public abstract class JsonSurferTest {
         }
         verify(mock, times(2)).onValue(anyObject(), any(ParsingContext.class));
     }
-
+    
+    @Test
+    public void testCollectOneFoundNothing() throws Exception {
+        String jsonPathFoundNothing = "$..authors";
+        surfer.collectOne(read("sample.json"), jsonPathFoundNothing);
+    }
 }

--- a/jsurfer-all/src/test/java/org/jsfr/json/JsonSurferTest.java
+++ b/jsurfer-all/src/test/java/org/jsfr/json/JsonSurferTest.java
@@ -742,6 +742,7 @@ public abstract class JsonSurferTest {
     @Test
     public void testCollectOneFoundNothing() throws Exception {
         String jsonPathFoundNothing = "$..authors";
-        surfer.collectOne(read("sample.json"), jsonPathFoundNothing);
+        Object expireNull = surfer.collectOne(read("sample.json"), jsonPathFoundNothing);
+        assertNull(expireNull);
     }
 }

--- a/jsurfer-jackson/src/main/java/org/jsfr/json/provider/JacksonProvider.java
+++ b/jsurfer-jackson/src/main/java/org/jsfr/json/provider/JacksonProvider.java
@@ -33,85 +33,88 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jsfr.json.exception.JsonSurfingException;
 
 public class JacksonProvider implements JsonProvider<ObjectNode, ArrayNode, JsonNode> {
-
+    
     public static final JacksonProvider INSTANCE = new JacksonProvider();
-
+    
     private ObjectMapper om;
+    
     private JsonNodeFactory factory;
-
+    
     public JacksonProvider() {
         this(new ObjectMapper());
     }
-
+    
     public JacksonProvider(ObjectMapper om) {
         this.om = om;
         this.factory = om.getNodeFactory();
     }
-
+    
     @Override
     public ObjectNode createObject() {
         return factory.objectNode();
     }
-
+    
     @Override
     public ArrayNode createArray() {
         return factory.arrayNode();
     }
-
+    
     @Override
     public void put(ObjectNode object, String key, JsonNode value) {
         object.set(key, value);
     }
-
+    
     @Override
     public void add(ArrayNode array, JsonNode value) {
         array.add(value);
     }
-
+    
     @Override
     public Object resolve(ObjectNode object, String key) {
         return object.get(key);
     }
-
+    
     @Override
     public Object resolve(ArrayNode array, int index) {
         return array.get(index);
     }
-
+    
     @Override
     public JsonNode primitive(boolean value) {
         return factory.booleanNode(value);
     }
-
+    
     @Override
     public JsonNode primitive(int value) {
         return factory.numberNode(value);
     }
-
+    
     @Override
     public JsonNode primitive(double value) {
         return factory.numberNode(value);
     }
-
+    
     @Override
     public JsonNode primitive(long value) {
         return factory.numberNode(value);
     }
-
+    
     @Override
     public JsonNode primitive(String value) {
         return factory.textNode(value);
     }
-
+    
     @Override
     public JsonNode primitiveNull() {
         return factory.nullNode();
     }
-
+    
     @Override
     public <T> T cast(JsonNode value, Class<T> tClass) {
         try {
-            if (om.canDeserialize(om.getTypeFactory().constructType(tClass))) {
+            if (value == null) {
+                return null;
+            } else if (om.canDeserialize(om.getTypeFactory().constructType(tClass))) {
                 return om.treeToValue(value, tClass);
             } else {
                 return tClass.cast(value);
@@ -120,5 +123,5 @@ public class JacksonProvider implements JsonProvider<ObjectNode, ArrayNode, Json
             throw new JsonSurfingException(e);
         }
     }
-
+    
 }


### PR DESCRIPTION
When i searching something not found using the JsonSurferJackson instance as below.
```java
JsonSurfer surfer = JsonSurferJackson.INSTANCE;
surfer.collectOne(read("sample.json"), "$..authors"); // no authors in sample.json
```
Then I get a NullPointerException as below.
```
java.lang.NullPointerException
	at com.fasterxml.jackson.databind.ObjectMapper.treeToValue(ObjectMapper.java:2738)
	at org.jsfr.json.provider.JacksonProvider.cast(JacksonProvider.java:115)
	at org.jsfr.json.provider.JacksonProvider.cast(JacksonProvider.java:35)
	at org.jsfr.json.JsonSurfer.collectOne(JsonSurfer.java:418)
	at org.jsfr.json.JsonSurfer.collectOne(JsonSurfer.java:400)
	at org.jsfr.json.JsonSurfer.collectOne(JsonSurfer.java:389)
        ...
```

So I debug it, found that problem cause by calling `org.jsfr.json.provider.JacksonProvider#cast` with null JsonNode param，because there's no null value checking nethier in `org.jsfr.json.provider.JacksonProvider#cast` nor in `com.fasterxml.jackson.databind.ObjectMapper#treeToValue`.

This pull request to fix ahead problem.

The problen was not found when using the three other providers (Gson, JsonSimple, Fastjson ).

