### PR TITLE
Make SurfingContext class public

### DIFF
--- a/jsurfer-core/src/main/java/org/jsfr/json/SurfingContext.java
+++ b/jsurfer-core/src/main/java/org/jsfr/json/SurfingContext.java
@@ -39,7 +39,7 @@ import java.util.Map;
 /**
  * SurfingContext is not thread-safe
  */
-class SurfingContext implements ParsingContext, JsonSaxHandler {
+public class SurfingContext implements ParsingContext, JsonSaxHandler {
 
     private boolean stopped = false;
     private boolean paused = false;


### PR DESCRIPTION
Access to the class is needed in order to write custom/experimental `JsonParserAdapter` implementations, for example when implementing `JsonParserAdapter.parse()` and `JsonParserAdapter.create*Parser()`, which accept the constructed `SurfingContext`.

The `SurfingContext` constructor can meanwhile remain package-private and be constructed only via `JsonSurfer`