### PR TITLE
Update fast-json, gson and jackson versions to latest

### DIFF
--- a/jsurfer-fastjson/pom.xml
+++ b/jsurfer-fastjson/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.46</version>
+            <version>1.2.76</version>
         </dependency>
     </dependencies>
 

--- a/jsurfer-gson/pom.xml
+++ b/jsurfer-gson/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.2</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>com.github.jsurfer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.host.url>http://localhost:32768</sonar.host.url>
-        <jackson.version>2.9.4</jackson.version>
+        <jackson.version>2.12.4</jackson.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
As per title, update:

* Fast-json 1.2.76
* Gson to 2.8.7
* Jackson to 2.12.4

All unit tests pass so I think this should be safe.
